### PR TITLE
NLog 4.4.12, new Logger("name"), and README additions

### DIFF
--- a/NLog.FSharp/AssemblyInfo.fs
+++ b/NLog.FSharp/AssemblyInfo.fs
@@ -16,7 +16,7 @@ open System.Runtime.InteropServices
 
 [<assembly: Guid("69C41A83-5BCA-440F-A372-BD424DE2AB3E")>]
 
-[<assembly: AssemblyVersion("4.2.3")>]
-[<assembly: AssemblyFileVersion("4.2.3")>]
+[<assembly: AssemblyVersion("4.4.12")>]
+[<assembly: AssemblyFileVersion("4.4.12")>]
 
 do ()

--- a/NLog.FSharp/Logger.fs
+++ b/NLog.FSharp/Logger.fs
@@ -16,8 +16,11 @@ type ILogger =
     abstract Fatal: fmt: Printf.StringFormat<'a, unit> -> 'a
     abstract FatalException: e: Exception -> fmt: Printf.StringFormat<'a, unit> -> 'a
 
-type Logger(logger: NLog.Logger ) =
+type Logger(logger: NLog.Logger) =
     let logger = logger
+
+    new(name: string) =
+        Logger(NLog.LogManager.GetLogger(name))
 
     new() = 
         let callerType = 
@@ -25,7 +28,7 @@ type Logger(logger: NLog.Logger ) =
                 .GetFrames().[0]
                 .GetMethod()
                 .DeclaringType
-        Logger(NLog.LogManager.GetLogger(callerType.Name))
+        Logger(callerType.Name)
     
     member __.Trace fmt =
         Printf.kprintf (fun s -> logger.Trace(s)) fmt

--- a/NLog.FSharp/NLog.FSharp.fsproj
+++ b/NLog.FSharp/NLog.FSharp.fsproj
@@ -59,8 +59,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog">
-      <HintPath>..\packages\NLog.4.2.3\lib\net40\NLog.dll</HintPath>
       <Private>True</Private>
+      <HintPath>..\packages\NLog.4.4.12\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NLog.FSharp/NLog.FSharp.nuspec
+++ b/NLog.FSharp/NLog.FSharp.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>NLog.FSharp</id>
-    <version>4.2.3</version>
+    <version>4.4.12</version>
     <title>NLog FSharp</title>
     <authors>Marcin Deptuła</authors>
     <owners>Marcin Deptuła</owners>
@@ -10,10 +10,10 @@
     <projectUrl>https://github.com/Ravadre/NLog.FSharp</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>F# helpers for NLog</description>
-    <copyright>Copyright Marcin Deptuła 2014-2016</copyright>
+    <copyright>Copyright Marcin Deptuła 2014-2018</copyright>
     <tags>NLog FSharp F#</tags>
 	<dependencies>
-		<dependency id="NLog" version="4.2.3" />
+		<dependency id="NLog" version="4.4.12" />
 	</dependencies>
   </metadata>
   <files>

--- a/NLog.FSharp/packages.config
+++ b/NLog.FSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.2.3" targetFramework="net40" />
+  <package id="NLog" version="4.4.12" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -2,3 +2,44 @@ NLog.FSharp
 ===========
 
 Simple F# helper for NLog
+
+## Installation
+
+ - [NuGet](https://www.nuget.org/packages/NLog.FSharp/)
+   - Using the Package Manager Console:
+
+     ```
+      PM> Install-Package NLog.FSharp
+     ```
+
+   - Using [paket](https://fsprojects.github.io/Paket/):
+
+     ```
+      >./.paket/paket.exe add NLog.FSharp --project MyProject
+     ```
+
+## Examples
+
+```
+>open NLog.FSharp
+
+>let log = new Logger()        // logger name is determined using the caller type
+>let log = new Logger("mylog") // or use an explicit logger name
+>let log = new Logger(logger)  // or any NLog.Logger
+
+>let text = "Welcome"
+>log.Info "Text:%s" text       // <- use formatted text
+
+// use formatted input with any of these:
+>log.{Trace, Debug, Info, Warn, Error, Fatal} "More than one number %M or %i" 3.0m 7
+
+// or with exceptions
+>let e, i = new System.Exception(), 3
+>log.InfoException e "An exception has occurred %d times" i
+```
+
+More examples of formatted text in F# are available [here](https://fsharpforfunandprofit.com/posts/printf/).
+
+## Configuration
+
+For information on NLog configuration files, visit the [NLog wiki](https://github.com/nlog/NLog/wiki/Configuration-file).  Use this resource to determine what to log and where to log it when you need to capture output at runtime.


### PR DESCRIPTION
Update
- nuget package updated to NLog 4.4.12
- nuspec and assembly versions reflect change to 4.4.12
- adds some basic help for visitors (quickstart, links for formatted text & nlog config)

Adds
- Logger constructor accepts (name:string) as well